### PR TITLE
Add backround blur toggle, fix default mic and cam off state

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; frame-src 'self' https://*.daily.co; script-src 'self' https://unpkg.com/@daily-co/daily-js 'unsafe-eval'; connect-src https://*.daily.co https://*.pluot.blue wss:; worker-src 'self' blob:; style-src-elem 'self' https://fonts.googleapis.com/css2; font-src 'self' https://fonts.gstatic.com/s/roboto/v29/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2 https://fonts.gstatic.com/s/roboto/v29/KFOmCnqEu92Fr1Mu4mxKKTU1Kg.woff2 https://*.gstatic.com"
+      content="default-src 'self'; frame-src 'self'; script-src 'self' https://unpkg.com/@daily-co/daily-js 'unsafe-eval' https://cdn.jsdelivr.net/npm/@mediapipe/; connect-src https://*.daily.co https://*.pluot.blue https://cdn.jsdelivr.net/npm/@mediapipe/ wss:; worker-src 'self' blob:; style-src-elem 'self' https://fonts.googleapis.com/css2; font-src 'self' https://fonts.gstatic.com/s/roboto/v29/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2 https://fonts.gstatic.com/s/roboto/v29/KFOmCnqEu92Fr1Mu4mxKKTU1Kg.woff2 https://*.gstatic.com"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=Roboto&display=swap"
@@ -25,6 +25,7 @@
         <button id="toggleMic"></button>
         <button id="clipboard" class="invite"></button>
         <span id="clipboardTooltip">Room URL copied</span>
+        <button id="toggleBlur" class="blur-off">B</button>
         <button id="leave">Leave Call</button>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <button id="toggleMic"></button>
         <button id="clipboard" class="invite"></button>
         <span id="clipboardTooltip">Room URL copied</span>
-        <button id="toggleBlur" class="blur-off">B</button>
+        <button id="toggleBlur" class="blur-off">BLUR</button>
         <button id="leave">Leave Call</button>
       </div>
 

--- a/renderer/call/daily.js
+++ b/renderer/call/daily.js
@@ -8,6 +8,8 @@ import {
   updateCamBtn,
   updateCallControls,
   updateMicBtn,
+  registerBlurBtnListener,
+  updateBlurBtn,
 } from "./nav.js";
 import {
   addOrUpdateTile,
@@ -20,14 +22,16 @@ const playableState = "playable";
 
 let callObject = null;
 let localState = {
-  audio: false,
-  video: false,
+  audio: null,
+  video: null,
+  blur: false,
 };
 
 registerJoinListener(initAndJoin);
 registerLeaveBtnListener(leave);
 registerCamBtnListener(toggleCamera);
 registerMicBtnListener(toggleMicrophone);
+registerBlurBtnListener(toggleBlur);
 
 async function initAndJoin(roomURL, name) {
   callObject = DailyIframe.createCallObject({
@@ -42,7 +46,8 @@ async function initAndJoin(roomURL, name) {
     .on("participant-updated", handleParticipantUpdated)
     .on("participant-joined", handleParticipantJoined)
     .on("participant-left", handleParticipantLeft)
-    .on("active-speaker-change", handleActiveSpeakerChange);
+    .on("active-speaker-change", handleActiveSpeakerChange)
+    .on("input-settings-updated", handleInputSettingsChange);
 
   return callObject
     .join({ url: roomURL, userName: name })
@@ -67,6 +72,27 @@ function toggleCamera() {
 
 function toggleMicrophone() {
   callObject.setLocalAudio(!localState.audio);
+}
+
+function toggleBlur() {
+  let type, config;
+  if (!localState.blur) {
+    type = "background-blur";
+    config = { strength: 0.95 };
+  } else {
+    type = "none";
+  }
+
+  console.log("togging blur:", type, config);
+
+  callObject.updateInputSettings({
+    video: {
+      processor: {
+        type: type,
+        config: config,
+      },
+    },
+  });
 }
 
 function handleCameraError(event) {
@@ -125,6 +151,12 @@ function handleParticipantLeft(event) {
 function handleActiveSpeakerChange(event) {
   console.log("active speaker change", event.activeSpeaker.peerId);
   updateActiveSpeaker(event.activeSpeaker.peerId);
+}
+
+function handleInputSettingsChange(event) {
+  localState.blur =
+    event.inputSettings?.video?.processor?.type === "background-blur";
+  updateBlurBtn(localState.blur);
 }
 
 function updateLocal(p) {

--- a/renderer/call/daily.js
+++ b/renderer/call/daily.js
@@ -83,8 +83,6 @@ function toggleBlur() {
     type = "none";
   }
 
-  console.log("togging blur:", type, config);
-
   callObject.updateInputSettings({
     video: {
       processor: {

--- a/renderer/call/nav.js
+++ b/renderer/call/nav.js
@@ -4,6 +4,7 @@ import { setupDraggableElement } from "./drag.js";
 
 const toggleCamBtn = document.getElementById("toggleCam");
 const toggleMicBtn = document.getElementById("toggleMic");
+const toggleBlurBtn = document.getElementById("toggleBlur");
 const callControls = document.getElementById("callControls");
 
 setupDraggableElement(callControls);
@@ -42,6 +43,10 @@ export function registerMicBtnListener(f) {
   toggleMicBtn.addEventListener("click", f);
 }
 
+export function registerBlurBtnListener(f) {
+  toggleBlurBtn.addEventListener("click", f);
+}
+
 export function updateCallControls(inCall) {
   const controls = document.getElementById("callControls");
   // If the user has joined a call, remove the call entry form
@@ -72,6 +77,17 @@ export function updateMicBtn(micOn) {
   if (!micOn && !toggleMicBtn.classList.contains("mic-off")) {
     toggleMicBtn.classList.remove("mic-on");
     toggleMicBtn.classList.add("mic-off");
+  }
+}
+
+export function updateBlurBtn(blurOn) {
+  if (blurOn && !toggleBlurBtn.classList.contains("mic-on")) {
+    toggleBlurBtn.classList.remove("blur-off");
+    toggleBlurBtn.classList.add("blur-on");
+  }
+  if (!blurOn && !toggleBlurBtn.classList.contains("blur-off")) {
+    toggleBlurBtn.classList.remove("blur-on");
+    toggleBlurBtn.classList.add("blur-off");
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -53,7 +53,7 @@ video {
 
   position: absolute;
 
-  width: 265px;
+  width: 300px;
   height: 56px;
 
   left: calc(50% - 265px / 2);
@@ -92,18 +92,21 @@ video {
 
 #toggleCam,
 #toggleMic,
+#toggleBlur,
 #clipboard {
   width: 30px;
   height: 30px;
   border: none;
   background-color: transparent;
+  border-radius: 5px;
 }
 
 #toggleCam:hover,
 #toggleMic:hover,
+#toggleBlur:hover,
 #clipboard:hover {
   background: rgba(245, 245, 245, 0.6);
-  border-radius: 4px;
+  border-radius: 5px;
 }
 
 #leave {
@@ -123,7 +126,7 @@ video {
 }
 
 #callControls button {
-  margin: 0 8px;
+  margin: 0 5px;
   cursor: pointer;
 }
 
@@ -149,6 +152,16 @@ video {
   background-image: url("./assets/microphone-off.svg");
   background-repeat: no-repeat;
   background-position: center;
+}
+
+#callControls .blur-on {
+  background-color: #fff;
+  color: #000;
+}
+
+#callControls .blur-off {
+  background-color: #f63135;
+  color: #fff;
 }
 
 #clipboard.invite {

--- a/styles.css
+++ b/styles.css
@@ -92,21 +92,20 @@ video {
 
 #toggleCam,
 #toggleMic,
-#toggleBlur,
 #clipboard {
   width: 30px;
   height: 30px;
   border: none;
   background-color: transparent;
   border-radius: 5px;
+  size: 10px;
 }
 
-#toggleCam:hover,
-#toggleMic:hover,
-#toggleBlur:hover,
-#clipboard:hover {
-  background: rgba(245, 245, 245, 0.6);
+#toggleBlur {
+  height: 30px;
+  border: none;
   border-radius: 5px;
+  font-size: 10px;
 }
 
 #leave {
@@ -160,8 +159,16 @@ video {
 }
 
 #callControls .blur-off {
-  background-color: #f63135;
-  color: #fff;
+  background-color: #e2fbfd;
+  color: #2b3f56;
+}
+
+#toggleCam:hover,
+#toggleMic:hover,
+#toggleBlur:hover,
+#clipboard:hover {
+  background-color: rgba(245, 245, 245, 0.6);
+  border-radius: 5px;
 }
 
 #clipboard.invite {


### PR DESCRIPTION
I know we don't want code for the background blur post, but I felt like I needed a gif to show the behavior with a custom call object anyway, so went ahead and added the feature to the call overlay app to get the footage.

Do we want this? Is it just cluttering the Electron demo? I can just use the gif in the post and ditch this PR if so. Otherwise, I was thinking we could include a link to the diff of this PR in the blur blog post to show people an example of how they could add a quick version of this feature to an existing call object app, maybe..